### PR TITLE
GitHub Action to lint Python code

### DIFF
--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -25,7 +25,7 @@ jobs:
       - run: isort --check-only --profile black . || true
       - run: pip install --editable .
       - if: matrix.python-version >= 3.6
-      - run: |
+        run: |
           mkdir --parents --verbose .mypy_cache
           mypy --ignore-missing-imports --install-types --non-interactive . || true
       - run: pytest --doctest-modules .

--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -5,7 +5,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.5', '3.6', '3.8', '3.9']  # `pip install --editable .` is SLOW on Py35 and Py310 
+        python-version: ['3.5', '3.6', '3.8']  # `pip install --editable .` is SLOW on Py35, Py39, and Py310 
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -20,7 +20,7 @@ jobs:
         run: |
           pip install black flake8-2020
           black --check . || true
-      - run: codespell || true  # --ignore-words-list="" --skip="*.css,*.js,*.lock"
+      - run: codespell  # --ignore-words-list="" --skip="*.css,*.js,*.lock"
       - run: flake8 . --ignore=E123,E126,E131,E226 --max-complexity=10 --max-line-length=140 --show-source --statistics
       - run: isort --check-only --profile black . || true
       - run: pip install --editable .

--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -1,0 +1,28 @@
+name: lint_python
+on: [pull_request, push]
+jobs:
+  lint_python:
+    strategy:
+      fail-fast: false
+      python-version: ['3.5', '3.6', '3.7']  # , '3.8', '3.9', '3.10']
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+      - run: pip install --upgrade pip wheel
+      - run: pip install bandit black codespell flake8 flake8-2020 flake8-bugbear
+                         flake8-comprehensions isort pytest pyupgrade safety  # mypy
+      - run: bandit --recursive --skip B101 .  # B101 is assert statements
+      - run: black --check . || true
+      - run: codespell || true  # --ignore-words-list="" --skip="*.css,*.js,*.lock"
+      - run: flake8 . --ignore=E131 --max-complexity=10 --max-line-length=140 --show-source --statistics
+      - run: isort --check-only --profile black . || true
+      - run: pip install -r requirements.txt || pip install --editable . || pip install . || true
+      # - run: mkdir --parents --verbose .mypy_cache
+      # - run: mypy --ignore-missing-imports --install-types --non-interactive . || true
+      - run: pytest . || true
+      - run: pytest --doctest-modules . || true
+      - run: shopt -s globstar && pyupgrade --py36-plus **/*.py || true
+      - run: safety check

--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -23,10 +23,9 @@ jobs:
       - run: codespell || true  # --ignore-words-list="" --skip="*.css,*.js,*.lock"
       - run: flake8 . --ignore=E123,E126,E131,E226 --max-complexity=10 --max-line-length=140 --show-source --statistics
       - run: isort --check-only --profile black . || true
-      - run: pip install -r requirements.txt || pip install --editable . || pip install . || true
+      - run: pip install --editable .
       # - run: mkdir --parents --verbose .mypy_cache
       # - run: mypy --ignore-missing-imports --install-types --non-interactive . || true
-      - run: pytest . || true
-      - run: pytest --doctest-modules . || true
-      - run: shopt -s globstar && pyupgrade --py36-plus **/*.py || true
+      - run: pytest --doctest-modules .
+      - run: shopt -s globstar && pyupgrade --py36-plus **/*.py
       - run: safety check || true

--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -4,7 +4,8 @@ jobs:
   lint_python:
     strategy:
       fail-fast: false
-      python-version: ['3.5', '3.6', '3.7']  # , '3.8', '3.9', '3.10']
+      matrix:
+        python-version: ['3.5', '3.6', '3.7']  # , '3.8', '3.9', '3.10']
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -27,6 +27,7 @@ jobs:
       - if: matrix.python-version >= 3.6
         run: |
           mkdir --parents --verbose .mypy_cache
+          pip install mypy
           mypy --ignore-missing-imports --install-types --non-interactive . || true
       - run: pytest --doctest-modules .
       - run: shopt -s globstar && pyupgrade --py36-plus **/*.py

--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -5,7 +5,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.5', '3.6', '3.8', '3.10']
+        python-version: ['3.5', '3.6', '3.8', '3.9']  # `pip install --editable .` is SLOW on Py35 and Py310 
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -14,7 +14,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - run: pip install --upgrade pip wheel
       - run: pip install bandit codespell flake8 flake8-bugbear
-                         flake8-comprehensions isort pytest pyupgrade safety  # mypy
+                         flake8-comprehensions isort pytest pyupgrade safety
       - run: bandit --recursive --skip B101 .  # B101 is assert statements
       - if: matrix.python-version >= 3.6
         run: |
@@ -24,8 +24,10 @@ jobs:
       - run: flake8 . --ignore=E123,E126,E131,E226 --max-complexity=10 --max-line-length=140 --show-source --statistics
       - run: isort --check-only --profile black . || true
       - run: pip install --editable .
-      # - run: mkdir --parents --verbose .mypy_cache
-      # - run: mypy --ignore-missing-imports --install-types --non-interactive . || true
+      - if: matrix.python-version >= 3.6
+      - run: |
+          mkdir --parents --verbose .mypy_cache
+          mypy --ignore-missing-imports --install-types --non-interactive . || true
       - run: pytest --doctest-modules .
       - run: shopt -s globstar && pyupgrade --py36-plus **/*.py
       - run: safety check || true

--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -5,7 +5,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.5', '3.6', '3.7']  # , '3.8', '3.9', '3.10']
+        python-version: ['3.5', '3.6', '3.8', '3.10']
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -13,12 +13,12 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - run: pip install --upgrade pip wheel
-      - run: pip install bandit codespell flake8 flake8-2020 flake8-bugbear
+      - run: pip install bandit codespell flake8 flake8-bugbear
                          flake8-comprehensions isort pytest pyupgrade safety  # mypy
       - run: bandit --recursive --skip B101 .  # B101 is assert statements
       - if: matrix.python-version >= 3.6
         run: |
-          pip install black
+          pip install black flake8-2020
           black --check . || true
       - run: codespell || true  # --ignore-words-list="" --skip="*.css,*.js,*.lock"
       - run: flake8 . --ignore=E123,E126,E131,E226 --max-complexity=10 --max-line-length=140 --show-source --statistics
@@ -29,4 +29,4 @@ jobs:
       - run: pytest . || true
       - run: pytest --doctest-modules . || true
       - run: shopt -s globstar && pyupgrade --py36-plus **/*.py || true
-      - run: safety check
+      - run: safety check || true

--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -13,12 +13,15 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - run: pip install --upgrade pip wheel
-      - run: pip install bandit black codespell flake8 flake8-2020 flake8-bugbear
+      - run: pip install bandit codespell flake8 flake8-2020 flake8-bugbear
                          flake8-comprehensions isort pytest pyupgrade safety  # mypy
       - run: bandit --recursive --skip B101 .  # B101 is assert statements
-      - run: black --check . || true
+      - if: matrix.python-version >= 3.6
+        run: |
+          pip install black
+          black --check . || true
       - run: codespell || true  # --ignore-words-list="" --skip="*.css,*.js,*.lock"
-      - run: flake8 . --ignore=E131 --max-complexity=10 --max-line-length=140 --show-source --statistics
+      - run: flake8 . --ignore=E123,E126,E131,E226 --max-complexity=10 --max-line-length=140 --show-source --statistics
       - run: isort --check-only --profile black . || true
       - run: pip install -r requirements.txt || pip install --editable . || pip install . || true
       # - run: mkdir --parents --verbose .mypy_cache


### PR DESCRIPTION
Test results: https://github.com/cclauss/tvnews/actions
* Python 3.5 and 3.9 have slow pip install processes.  It passes on bandit codespell, flake8, pytest, and pyupgrade.
* Python 3.6-3.8 have fast pip install processes.  It passes on bandit codespell, flake8, mypy, pytest, and pyupgrade.
* Python 3.10 has a slow pip install process that eventually fails.

Several dependencies have security issues...
```
safety check || true
+==============================================================================+
|                                                                              |
|                               /$$$$$$            /$$                         |
|                              /$$__  $$          | $$                         |
|           /$$$$$$$  /$$$$$$ | $$  \__//$$$$$$  /$$$$$$   /$$   /$$           |
|          /$$_____/ |____  $$| $$$$   /$$__  $$|_  $$_/  | $$  | $$           |
|         |  $$$$$$   /$$$$$$$| $$_/  | $$$$$$$$  | $$    | $$  | $$           |
|          \____  $$ /$$__  $$| $$    | $$_____/  | $$ /$$| $$  | $$           |
|          /$$$$$$$/|  $$$$$$$| $$    |  $$$$$$$  |  $$$$/|  $$$$$$$           |
|         |_______/  \_______/|__/     \_______/   \___/   \____  $$           |
|                                                          /$$  | $$           |
|                                                         |  $$$$$$/           |
|  by pyup.io                                              \______/            |
|                                                                              |
+==============================================================================+
| REPORT                                                                       |
| checked 61 packages, using free DB (updated once a month)                    |
+============================+===========+==========================+==========+
| package                    | installed | affected                 | ID       |
+============================+===========+==========================+==========+
| thinc                      | 7.4.1     | <8.0.4                   | 40660    |
| pyyaml                     | 5.3.1     | <5.4                     | 39611    |
| pip                        | 20.3.4    | <21.1                    | 40291    |
| pip                        | 20.3.4    | <21.1                    | 42559    |
| numpy                      | 1.18.5    | <1.21.0rc1               | 43453    |
| numpy                      | 1.18.5    | <1.22.0                  | 44717    |
| numpy                      | 1.18.5    | <1.22.0                  | 44716    |
| numpy                      | 1.18.5    | <1.22.2                  | 44715    |
| click                      | 7.1.2     | <8.0.0                   | 47833    |
+==============================================================================+
```
